### PR TITLE
Add note about availability of global instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,23 @@ export default defineConfig({
 </script>
 ```
 
+**Note**: The global instance might not be available immediately since swup is loaded when the
+browser is idle. In that case, you can listen for the `enable` event on the document.
+
+```html
+<script>
+  const setup = () => {
+    window.swup.use(new MyCustomSwupPlugin())
+    window.swup.hooks.on('page:view', () => {})
+  }
+  if (window.swup) {
+    setup()
+  } else {
+    document.addEventListener('swup:enable', setup)
+  }
+</script>
+```
+
 ### Control over the initialization
 
 If you need more granularity during the initilization process itself, consider following


### PR DESCRIPTION
**Description**

- The global instance `window.swup` is not available immediately
- Add note in readme an example code listening for the `swup:enable` event

**Checks**

- [x] The PR is submitted to the `master` branch
- [ ] ~~The code was linted before pushing (`npm run lint`)~~
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required

**Additional information**

Closes #7