### PR TITLE
Allow setting theme options

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ Set to `false` if you want to define your own animation styles.
 }
 ```
 
+Pass in an array with the theme name and an object to override specific theme options:
+
+```js
+{
+  theme: ['overlay', { direction: 'to-right' }]
+}
+```
+
 ### config.animationClass
 
 If you're not using one of the provided themes, you will need this class for defining your own

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export interface Options {
 	reloadScripts: boolean;
 	routes: true | false | Route[];
 	smoothScrolling: boolean;
-	theme: Theme | false;
+	theme: Theme | [Theme, ThemeOptions] | false;
 	updateBodyClass: boolean;
 	updateHead: boolean;
 }
@@ -27,6 +27,8 @@ export enum Theme {
 	slide = 'slide',
 	overlay = 'overlay'
 }
+
+export type ThemeOptions = Record<string, unknown>;
 
 export interface Route {
 	name: string;

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,4 +1,4 @@
-import { Theme, type Options } from './index.js';
+import { Theme, type ThemeOptions, type Options } from './index.js';
 
 export function buildInitScript(options: Partial<Options> = {}): string {
 	let {
@@ -21,8 +21,17 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 		updateHead = true,
 	} = options;
 
-	// Get main element for themes from first container
-	const mainElement = containers[0];
+	// Override main element for themes from first container
+	let themeOptions: ThemeOptions = {
+		mainElement: containers[0]
+	};
+
+	// Allow theme to be passed as an array with name + options
+	// e.g. ['overlay', { direction: 'to-right' }]
+	if (Array.isArray(theme)) {
+		themeOptions = { ...themeOptions, ...theme[1] };
+		theme = theme[0];
+	}
 
 	// Build animation selector from animation class
 	const animationSelector = animationClass ? `[class*="${animationClass}"]` : false;
@@ -106,9 +115,9 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 					${updateBodyClass ? `new SwupBodyClassPlugin(),` : ''}
 					${updateHead ? `new SwupHeadPlugin({ awaitAssets: true }),` : ''}
 					${reloadScripts ? `new SwupScriptsPlugin(),` : ''}
-					${theme === Theme.fade ? `new SwupFadeTheme({ mainElement: ${JSON.stringify(mainElement)} }),` : ''}
-					${theme === Theme.slide ? `new SwupSlideTheme({ mainElement: ${JSON.stringify(mainElement)} }),` : ''}
-					${theme === Theme.overlay ? `new SwupOverlayTheme(),` : ''}
+					${theme === Theme.fade ? `new SwupFadeTheme(${JSON.stringify(themeOptions)}),` : ''}
+					${theme === Theme.slide ? `new SwupSlideTheme(${JSON.stringify(themeOptions)}),` : ''}
+					${theme === Theme.overlay ? `new SwupOverlayTheme(${JSON.stringify(themeOptions)}),` : ''}
 				]
 			});
 			${globalInstance ? 'window.swup = swup;' : ''}


### PR DESCRIPTION
**Description**

Allow passing in theme options as second argument:

```js
{
  theme: ['overlay', { direction: 'to-right' }]
}
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required

**Additional information**

Closes #11 