### PR TITLE
Serialise options & refactor imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     ".": "./dist/index.js",
     "./client": "./dist/client.js",
     "./client/*": "./dist/client/*.js",
+    "./serialise": "./dist/serialise.js",
     "./idle": "./dist/idle.js",
     "./package.json": "./package.json"
   },

--- a/src/script.ts
+++ b/src/script.ts
@@ -119,7 +119,7 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 				containers: ${JSON.stringify(containers)},
 				cache: ${JSON.stringify(cache)},
 				plugins: [
-					${Object.entries(enabledPlugins).map(([plugin, options]) => s`new ${plugin}(${options}),`).join(', ')}
+					${Object.entries(enabledPlugins).map(([plugin, options]) => s`new ${plugin}(${options})`).join(', ')}
 				]
 			});
 

--- a/src/script.ts
+++ b/src/script.ts
@@ -78,7 +78,7 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 		SwupMorphPlugin: morph ? { containers: morph } : false,
 		SwupPreloadPlugin: preload ? { preloadHoveredLinks: preload.hover, preloadVisibleLinks: preload.visible } : false,
 		SwupProgressPlugin: progress,
-		SwupRouteNamePlugin: routes ? { routes: routes, paths: true } : false,
+		SwupRouteNamePlugin: routes ? { routes, paths: true } : false,
 		SwupScrollPlugin: smoothScrolling,
 		SwupParallelPlugin: parallel ? { containers: parallel } : false,
 		SwupBodyClassPlugin: updateBodyClass,

--- a/src/script.ts
+++ b/src/script.ts
@@ -49,6 +49,7 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 	} else {
 		preload = { hover: preload, visible: false };
 	}
+
 	// Unset preload if all preload options are disabled
 	if (Object.values(preload).filter(Boolean).length === 0) {
 		preload = false;
@@ -69,7 +70,6 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 		morph = false;
 	}
 
-	// Create import statements from requested features
 	// Build plugins + options from requested features
 	const plugins = {
 		SwupDebugPlugin: debug,
@@ -89,9 +89,10 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 		SwupOverlayTheme: theme === Theme.overlay ? themeOptions : false,
 	};
 
+	// Only enable plugins that are requested
 	const enabledPlugins = Object.fromEntries(Object.entries(plugins).filter(([, enabled]) => enabled));
 
-	// Create import statements from swup and enabled plugins
+	// Create import statements for swup and enabled plugins
 	// This gets injected into the user's page, so we need to re-export Swup and all plugins
 	// from our own package so that package managers like pnpm can follow the imports correctly
 	const modules = ['Swup', ...Object.keys(enabledPlugins)];
@@ -112,6 +113,7 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 
 		async function initSwup() {
 			${loadOnIdle ? dynamicImports : ''}
+
 			const swup = new Swup({
 				animationSelector: ${JSON.stringify(animationSelector)},
 				containers: ${JSON.stringify(containers)},
@@ -120,6 +122,7 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 					${Object.entries(enabledPlugins).map(([plugin, options]) => s`new ${plugin}(${options}),`).join(', ')}
 				]
 			});
+
 			${globalInstance ? 'window.swup = swup;' : ''}
 		}
 

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,4 +1,5 @@
 import { Theme, type ThemeOptions, type Options } from './index.js';
+import { serialiseOptions as s } from './serialise.js';
 
 export function buildInitScript(options: Partial<Options> = {}): string {
 	let {
@@ -63,38 +64,44 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 	}
 
 	// Create import statements from requested features
+	// Build plugins + options from requested features
+	const plugins = {
+		SwupDebugPlugin: debug,
+		SwupA11yPlugin: accessibility,
+		SwupFormsPlugin: forms ? { formSelector: 'form' } : false,
+		SwupMorphPlugin: morph ? { containers: morph } : false,
+		SwupPreloadPlugin: preload ? { preloadHoveredLinks: preload.hover, preloadVisibleLinks: preload.visible } : false,
+		SwupProgressPlugin: progress,
+		SwupRouteNamePlugin: routes ? { routes: routes, paths: true } : false,
+		SwupScrollPlugin: smoothScrolling,
+		SwupParallelPlugin: parallel ? { containers: parallel } : false,
+		SwupBodyClassPlugin: updateBodyClass,
+		SwupHeadPlugin: updateHead ? { awaitAssets: true } : false,
+		SwupScriptsPlugin: reloadScripts,
+		SwupFadeTheme: theme === Theme.fade ? themeOptions : false,
+		SwupSlideTheme: theme === Theme.slide ? themeOptions : false,
+		SwupOverlayTheme: theme === Theme.overlay ? themeOptions : false,
+	};
+
+	const enabledPlugins = Object.fromEntries(Object.entries(plugins).filter(([, enabled]) => enabled));
+
+	// Create import statements from swup and enabled plugins
 	// This gets injected into the user's page, so we need to re-export Swup and all plugins
 	// from our own package so that package managers like pnpm can follow the imports correctly
-	const imports = [
-		'Swup',
-		debug ? 'SwupDebugPlugin' : null,
-		accessibility ? 'SwupA11yPlugin' : null,
-		forms ? 'SwupFormsPlugin' : null,
-		preload ? 'SwupPreloadPlugin' : null,
-		progress ? 'SwupProgressPlugin' : null,
-		smoothScrolling ? 'SwupScrollPlugin' : null,
-		parallel ? 'SwupParallelPlugin' : null,
-		reloadScripts ? 'SwupScriptsPlugin' : null,
-		updateBodyClass ? 'SwupBodyClassPlugin' : null,
-		updateHead ? 'SwupHeadPlugin' : null,
-		routes ? 'SwupRouteNamePlugin' : null,
-		theme === Theme.fade ? 'SwupFadeTheme' : null,
-		theme === Theme.slide ? 'SwupSlideTheme' : null,
-		theme === Theme.overlay ? 'SwupOverlayTheme' : null,
-	].filter(Boolean);
-
-	// Create import statements
-
-	const staticImports = imports.map(pckg => `import ${pckg} from '@swup/astro/client/${pckg}'`).join('; ');
+	const modules = ['Swup', ...Object.keys(enabledPlugins)];
+	const imports = modules.map(pckg => [pckg, `@swup/astro/client/${pckg}`]);
+	const staticImports = imports.map(([pckg, path]) => `import ${pckg} from '${path}'`).join('; ');
 	const dynamicImports = `
-		const moduleImports = await Promise.all([${imports.map(pckg => `import('@swup/astro/client/${pckg}')`).join(',')}]);
-		const [${imports.join(', ')}] = moduleImports.map((m) => m.default);
+		const [${modules.join(', ')}] = await Promise.all([${imports.map(
+			([, path]) => `import('${path}').then((m) => m.default)`
+		).join(', ')}]);
 	`;
 
 	// Create swup init code from requested features
 
 	return `
-		import { onIdleAfterLoad } from '@swup/astro/idle';
+		import { deserialise } from '@swup/astro/serialise';
+		${loadOnIdle ? `import { onIdleAfterLoad } from '@swup/astro/idle';` : ''}
 		${!loadOnIdle ? staticImports : ''}
 
 		async function initSwup() {
@@ -104,20 +111,7 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 				containers: ${JSON.stringify(containers)},
 				cache: ${JSON.stringify(cache)},
 				plugins: [
-					${debug ? `new SwupDebugPlugin(),` : ''}
-					${accessibility ? `new SwupA11yPlugin(),` : ''}
-					${forms ? `new SwupFormsPlugin({ formSelector: 'form' }),` : ''}
-					${preload ? `new SwupPreloadPlugin({ preloadHoveredLinks: ${JSON.stringify(preload.hover)}, preloadVisibleLinks: ${JSON.stringify(preload.visible)} }),` : ''}
-					${progress ? `new SwupProgressPlugin(),` : ''}
-					${routes ? `new SwupRouteNamePlugin({ routes: ${JSON.stringify(routes)}, paths: true }),` : ''}
-					${smoothScrolling ? `new SwupScrollPlugin(),` : ''}
-					${parallel ? `new SwupParallelPlugin({ containers: ${JSON.stringify(parallel)} }),` : ''}
-					${updateBodyClass ? `new SwupBodyClassPlugin(),` : ''}
-					${updateHead ? `new SwupHeadPlugin({ awaitAssets: true }),` : ''}
-					${reloadScripts ? `new SwupScriptsPlugin(),` : ''}
-					${theme === Theme.fade ? `new SwupFadeTheme(${JSON.stringify(themeOptions)}),` : ''}
-					${theme === Theme.slide ? `new SwupSlideTheme(${JSON.stringify(themeOptions)}),` : ''}
-					${theme === Theme.overlay ? `new SwupOverlayTheme(${JSON.stringify(themeOptions)}),` : ''}
+					${Object.entries(enabledPlugins).map(([plugin, options]) => s`new ${plugin}(${options}),`).join(', ')}
 				]
 			});
 			${globalInstance ? 'window.swup = swup;' : ''}

--- a/src/serialise.ts
+++ b/src/serialise.ts
@@ -21,6 +21,9 @@ export function deserialise(serialised: string) {
 }
 
 function replacer(key: string, value: unknown) {
+	if (value instanceof RegExp) {
+		return [':regex:', value.toString()];
+	}
 	if (typeof value === 'function') {
 		let output = value.toString();
 		if (value.name && (new RegExp(`^\\s*${value.name}\\s*[(]`)).test(output)) {
@@ -32,9 +35,16 @@ function replacer(key: string, value: unknown) {
 }
 
 function reviver(key: string, value: unknown) {
-	if (Array.isArray(value) && value[0] === ':function:' && typeof value[1] === 'string') {
+	if (Array.isArray(value) && value.length === 2 && typeof value[1] === 'string') {
+		const type = value[0];
 		value = value[1];
-		return new Function(`return (${value}).apply(this, arguments);`);
+		if (type === ':regex:') {
+			const fragments = (value as string).match(/\/(.*?)\/([a-z]*)?$/i) || [];
+			return new RegExp(fragments[1], fragments[2] || '');
+		}
+		if (type === ':function:') {
+			return new Function(`return (${value}).apply(this, arguments);`);
+		}
 	}
 	return value;
 }

--- a/src/serialise.ts
+++ b/src/serialise.ts
@@ -1,0 +1,40 @@
+export function serialiseOptions(strings: TemplateStringsArray, ...substitutions: unknown[]): string {
+	return strings.reduce((acc, curr, i) => {
+		const substitution = substitutions[i];
+		if (typeof substitution === 'object') {
+			acc += `${curr}${serialise(substitution)}`;
+		} else if (substitution) {
+			acc += `${curr}${substitution}`;
+		} else {
+			acc += curr;
+		}
+		return acc;
+	}, '');
+}
+
+export function serialise(value: unknown) {
+	return `deserialise(${JSON.stringify(JSON.stringify(value, replacer))})`;
+}
+
+export function deserialise(serialised: string) {
+	return JSON.parse(serialised, reviver);
+}
+
+function replacer(key: string, value: unknown) {
+	if (typeof value === 'function') {
+		let output = value.toString();
+		if (value.name && (new RegExp(`^\\s*${value.name}\\s*[(]`)).test(output)) {
+			output = 'function ' + output;
+		}
+		return [':function:', output];
+	}
+	return value;
+}
+
+function reviver(key: string, value: unknown) {
+	if (Array.isArray(value) && value[0] === ':function:' && typeof value[1] === 'string') {
+		value = value[1];
+		return new Function(`return (${value}).apply(this, arguments);`);
+	}
+	return value;
+}


### PR DESCRIPTION
**Description**

- Serialise & deserialise plugin options using a custom JSON serialiser
- Goal: pass in functions and regex to swup and plugins, e.g. route-name patterns & morph callbacks
- While at it, refactor/simplify how plugin imports are concatenated from the integration options

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~The documentation was updated as required~~