### PR TITLE
Trigger custom events to simulate Astro lifecycle

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -123,6 +123,13 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 				]
 			});
 
+			const dispatch = (name) => document.dispatchEvent(new Event(name));
+
+			// Trigger custom events to simulate Astro load lifecycle
+			swup.hooks.before('content:replace', () => dispatch('astro:before-swap'));
+			swup.hooks.on('content:replace', () => dispatch('astro:after-swap'));
+			swup.hooks.on('page:view', () => dispatch('astro:page-load'));
+
 			${globalInstance ? 'window.swup = swup;' : ''}
 		}
 


### PR DESCRIPTION
**Description**

- Trigger custom events to allow cleanup of Astro islands from Vue/Svelte/etc. integrations
- Avoid memory leaks and other side effects
- As suggested by #27
- Tested locally in playground to confirm it fixes the issue

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [ ] The documentation was updated as required

**Additional information**

Closes #27 