### PR TITLE
Allow ignoring visits

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ export default defineConfig({
       cache: true,
       preload: true,
       accessibility: true,
+      ignore: null,
       forms: false,
       morph: false,
       parallel: false,
@@ -245,6 +246,35 @@ content after page visits.
 ```js
 {
   accessibility: true
+}
+```
+
+### config.ignore
+
+Tell swup to ignore certain links. This is useful for links that should always trigger a full reload,
+like links to an admin panel or links you know will download files. The default is to accept all
+links unless they are marked with a `data-no-swup` attribute.
+
+The ignore option accepts either an array of strings/regexps or a function that returns a boolean:
+
+- Regular expressions are matched against the url, e.g. `/\.pdf$/i`
+- Strings starting with a slash are matched against the beginning of the url, e.g. `/admin`
+- All other strings are used as CSS selectors and match against the clicked element, e.g. `a[download]`
+- Functions receive the url as well as the element and event that triggered the visit
+
+```js
+{
+  ignore: [
+    /\.pdf$/i,
+    '/admin',
+    'a[download]',
+  ]
+}
+```
+
+```js
+{
+  ignore: (url, { el, event }) => event.shiftKey
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export interface Options {
 	debug: boolean;
 	forms: boolean;
 	globalInstance: boolean;
+	ignore: (string|RegExp)[] | ((url: string, { el, event }: { el?: Element; event?: Event }) => boolean);
 	loadOnIdle: boolean;
 	parallel: boolean | string[];
 	morph: string[] | false;

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,5 +1,5 @@
 import { Theme, type ThemeOptions, type Options } from './index.js';
-import { serialiseOptions as s } from './serialise.js';
+import { serialiseOptions as s, serialise } from './serialise.js';
 
 export function buildInitScript(options: Partial<Options> = {}): string {
 	let {
@@ -10,6 +10,7 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 		debug = false,
 		forms = false,
 		globalInstance = false,
+		ignore = null,
 		loadOnIdle = true,
 		morph = false,
 		parallel = false,
@@ -113,6 +114,25 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 
 		async function initSwup() {
 			${loadOnIdle ? dynamicImports : ''}
+
+			const ignore = ${serialise(ignore)};
+			const ignoreVisit = (url, { el, event } = {}) => {
+				if (typeof ignore === 'function') {
+					return ignore(url, { el, event });
+				}
+				if (Array.isArray(ignore)) {
+					return ignore.some((pattern) => {
+						if (typeof pattern === 'string') {
+							return url.includes(pattern);
+						}
+						if (pattern instanceof RegExp) {
+							return pattern.test(url);
+						}
+						return false;
+					});
+				}
+				return false;
+			};
 
 			const swup = new Swup({
 				animationSelector: ${JSON.stringify(animationSelector)},

--- a/src/script.ts
+++ b/src/script.ts
@@ -135,12 +135,8 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 				return false;
 			};
 
-			const ignoreVisit = (url, { el, event } = {}) => {
-				return shouldIgnore(ignoreOption, url, { el, event });
-			};
-
 			const swup = new Swup({
-				ignoreVisit: (url, { el, event } = {}) => shouldIgnore(ignoreOption, url, { el, event }),
+				ignoreVisit: (url, { el, event } = {}) => el?.closest('[data-no-swup]') || shouldIgnore(ignoreOption, url, { el, event }),
 				animationSelector: ${JSON.stringify(animationSelector)},
 				containers: ${JSON.stringify(containers)},
 				cache: ${JSON.stringify(cache)},


### PR DESCRIPTION
**Description**

- Add a new `ignore` option for ignoring visits
- A bit more ergonomic that swup's internal `ignoreVisit` function
- Allows a function that forwards `ignoreVisit`, regular expressions (against the url), strings starting with a slash against the url, all other strings as CSS selector agains the element, and an array for a combination of all of them
- Hardwires the `data-no-swup` part to prevent people overwriting it
- Tested in the playground
- Closes #30 

**Examples**

```js
{
  ignore: [
    /\.pdf$/i,
    '/admin',
    'a[download]',
  ]
}
```

```js
{
  ignore: (url, { el, event }) => event.shiftKey
}
```

**Checks**

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required