### PR TITLE
feat: dispatch `astro:swup-ready` event when `globalInstance` and `loadOnIdle` are both used

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -152,7 +152,9 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 			swup.hooks.on('content:replace', () => dispatch('astro:after-swap'));
 			swup.hooks.on('page:view', () => dispatch('astro:page-load'));
 
-			${globalInstance ? 'window.swup = swup;' : ''}
+			${globalInstance
+				? `window.swup = swup; ${loadOnIdle ? `dispatch('astro:swup-ready');` : ''}`
+				: ''}
 		}
 
 		${loadOnIdle ? 'onIdleAfterLoad(initSwup);' : 'initSwup();'}


### PR DESCRIPTION
<!--
Thanks for creating this pull request!

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

**Description**

<!--
Clear and concise description of the proposed changes, as well as a convincing reason for adding them to swup.
-->
When using both `globalInstance: true` and `loadOnIdle: true`, it's useful to be able to know when `window.swup` is finally set. For example, you may want to add your own plugin, set plugin options, etc.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The documentation was updated as required

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
