### PR TITLE
Native view transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,34 @@ html.is-animating .transition-fade {
 }
 ```
 
+### Native view transitions
+
+For best performance in browsers that support it, you can enable swup's native mode and define animations using the [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API).
+
+```js
+export default defineConfig({
+  integrations: [
+    swup({ theme: false, native: true })
+  ]
+});
+```
+
+```css
+html.is-changing .transition-fade {
+  view-transition-name: main;
+}
+::view-transition-old(main) {
+  animation: fade 0.5s ease-in-out both;
+}
+::view-transition-new(main) {
+  animation: fade 0.5s ease-in-out both reverse;
+}
+@keyframes fade {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+```
+
 ### Usage without animations
 
 If you don't need animated page transitions and just want to use swup for its preloading and caching

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export interface Options {
 	loadOnIdle: boolean;
 	parallel: boolean | string[];
 	morph: string[] | false;
+	native: boolean;
 	preload: boolean | { hover: boolean; visible: boolean };
 	progress: boolean;
 	reloadScripts: boolean;

--- a/src/script.ts
+++ b/src/script.ts
@@ -13,6 +13,7 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 		ignore = null,
 		loadOnIdle = true,
 		morph = false,
+		native = false,
 		parallel = false,
 		preload = true,
 		progress = false,
@@ -146,6 +147,7 @@ export function buildInitScript(options: Partial<Options> = {}): string {
 				animationSelector: ${JSON.stringify(animationSelector)},
 				containers: ${JSON.stringify(containers)},
 				cache: ${JSON.stringify(cache)},
+				native: ${JSON.stringify(native)},
 				plugins: [
 					${Object.entries(enabledPlugins).map(([plugin, options]) => s`new ${plugin}(${options})`).join(', ')}
 				]


### PR DESCRIPTION
**Description**

Pass along `native` option to swup and document usage with native View Transition API.

**Checks**

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required

**Additional information**

Closes #35 
