### PR TITLE
Set up npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,17 +5,20 @@ name: Publish package
 on:
   release:
     types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # For OIDC Trusted Publishing
 
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
           registry-url: https://registry.npmjs.org
+          node-version: 24
       - run: npm ci
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
- Duplicated from Fragment Plugin's [related PR](https://github.com/swup/fragment-plugin/pull/98)
- Let's hope it works 🤠
- @hirasso Were there any additional steps aside from updating the action?